### PR TITLE
Implement ability to join related tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can chain joins as seen below:
 
 ##### Join Manually
 
-If you want to join tables that are not just linked by related keys you can manually add conditions to a join. To do this create a `new OmegaSearchJoin` and call the `addCondition` method to add your conditions. You must specify the local table name and the joined table name in the constructor. Optionally you can specify the join type, the default is `JOIN`
+If you want to join tables that are not just linked by related keys you can manually add conditions to a join. To do this create a new `OmegaSearchJoin` object and call the `addCondition` method to add your conditions. You must specify the local table name and the joined table name in the constructor. Optionally you can specify the join type, the default is `JOIN`
 
 When adding a condition the parameter on the left will automatically have the local table name prepended and the joined table name will be prepended to the right condition.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ paginated (`->paginate()`) as required.
 
 ## Joining Tables
 
-If you want to used joined tables to search your model simply override the `getOmegaSearchTablesToJoin` on your model and return an array of `OmegaSearchJoins`.
+If you want to search the content of related tables, you can use joins. Simply override the `getOmegaSearchTablesToJoin` on your model and return an array of `OmegaSearchJoins`.
 
 #### Defining Joins
 

--- a/README.md
+++ b/README.md
@@ -30,3 +30,71 @@ order of relevance.
 
 The related models can then be retrieved (`->get()`) or 
 paginated (`->paginate()`) as required.
+
+## Joining Tables
+
+If you want to used joined tables to search your model simply override the `getOmegaSearchTablesToJoin` on your model and return an array of `OmegaSearchJoins`.
+
+#### Defining Joins
+
+##### Join by related keys
+
+There are two ways to define joins. The first way is to call the `OmegaSearchJoin::joinTableByForeignKey` method. You have to pass the local table name and joined table name to this method.
+
+By default the key on the joined table will be the joined table name singularised with `_id` appended and the key on the local table will `id`. These can be set manually using the 3rd and 4th parameter for this method.
+
+See below for an example:
+```php
+    public function getOmegaSearchTablesToJoin()
+    {
+        return [
+            OmegaSearchJoin::joinTableByForeignKey($this->getTable(), 'divisions'),
+        ];
+    }
+```
+
+or
+
+
+```php
+    public function getOmegaSearchTablesToJoin()
+    {
+        return [
+            OmegaSearchJoin::joinTableByForeignKey($this->getTable(), 'divisions', 'id', 'division_id),
+        ];
+    }
+```
+
+You can chain joins as seen below:
+
+```php
+    public function getOmegaSearchTablesToJoin()
+    {
+        return [
+            OmegaSearchJoin::joinTableByForeignKey($this->getTable(), 'divisions'),
+            OmegaSearchJoin::joinTableByForeignKey('divisions', 'companies', 'id', 'company_id')
+        ];
+    }
+```
+
+
+
+##### Join Manually
+
+If you want to join tables that are not just linked by related keys you can manually add conditions to a join. To do this create a `new OmegaSearchJoin` and call the `addCondition` method to add your conditions. You must specify the local table name and the joined table name in the constructor. Optionally you can specify the join type, the default is `JOIN`
+
+When adding a condition the parameter on the left will automatically have the local table name prepended and the joined table name will be prepended to the right condition.
+
+See below for an example:
+
+```php
+    public function getOmegaSearchTablesToJoin()
+    {
+        $join = new OmegaSearchJoin('contacts', 'divisions', 'INNER JOIN');
+        $join->addCondition('gross_income', '>', 'annual_income');
+        
+        return [
+            $join,
+        ];
+    }
+```

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Easily add an intelligent search engine to your Laravel powered website or web application",
     "require": {
         "php": ">=7.1",
-        "divineomega/omega-search": "^4.0.2",
+        "divineomega/omega-search": "^4.1.0",
         "laravel/framework": "^5.1||^6.0"
     },
     "autoload": {

--- a/src/OmegaSearchJoin.php
+++ b/src/OmegaSearchJoin.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace DivineOmega\LaravelOmegaSearch;
+
+use Illuminate\Support\Str;
+
+class OmegaSearchJoin
+{
+    protected $joinedTable;
+    protected $localTable;
+    protected $conditions = [];
+    protected $joinType;
+
+    /**
+     * OmegaSearchJoin constructor.
+     * @param string $joinedTable
+     * @param string $localTable
+     * @param string $joinType
+     */
+    public function __construct($localTable, $joinedTable, $joinType = 'JOIN')
+    {
+        $this->joinedTable = $joinedTable;
+        $this->localTable = $localTable;
+        $this->joinType = $joinType;
+    }
+
+    /**
+     * @param string $localTable
+     * @param string $joinedTable
+     * @param string $foreignKey
+     * @param string|null $localKey
+     * @return OmegaSearchJoin
+     */
+    public static function joinTableByForeignKey($localTable, $joinedTable, $foreignKey = 'id', $localKey = false)
+    {
+        if (!$localKey) {
+            $localKey = Str::singular($joinedTable).'_id';
+        }
+
+        $join = new self($localTable, $joinedTable, 'LEFT JOIN');
+        $join->addCondition($localKey, '=', $foreignKey);
+
+        return $join;
+    }
+
+    /**
+     * @param string $localColumn
+     * @param string $operator
+     * @param string $foreignColumn
+     * @return $this
+     */
+    public function addCondition($localColumn, $operator, $foreignColumn)
+    {
+        $this->conditions[] = new OmegaSearchJoinCondition(
+            $this->localTable,
+            $this->joinedTable,
+            $localColumn,
+            $foreignColumn,
+            $operator
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSqlStatement()
+    {
+        $conditionStatements = array_map(function (OmegaSearchJoinCondition $condition) {
+            return $condition->getSqlStatement();
+        }, $this->conditions);
+
+        return $this->joinType . ' ' . $this->joinedTable . ' ON ' . implode(' AND ', $conditionStatements);
+    }
+}

--- a/src/OmegaSearchJoinCondition.php
+++ b/src/OmegaSearchJoinCondition.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace DivineOmega\LaravelOmegaSearch;
+
+
+class OmegaSearchJoinCondition
+{
+    protected $localTable;
+    protected $joinedTable;
+    protected $localColumn;
+    protected $foreignColumn;
+    protected $operator;
+
+    /**
+     * OmegaSearchJoinCondition constructor.
+     * @param string $localTable
+     * @param string $joinedTable
+     * @param string localColumn
+     * @param string $foreignColumn
+     * @param string operator
+     */
+    public function __construct($localTable, $joinedTable, $localColumn, $foreignColumn, $operator)
+    {
+        $this->localTable = $localTable;
+        $this->joinedTable = $joinedTable;
+        $this->localColumn = $localColumn;
+        $this->foreignColumn = $foreignColumn;
+        $this->operator = $operator;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSqlStatement(){
+        return $this->localTable . '.' . $this->localColumn . ' '
+            . $this->operator . ' '
+            . $this->joinedTable . '.' . $this->foreignColumn;
+    }
+}


### PR DESCRIPTION
`joinTableByForeignKey` could quite easily be wrapped by a method that takes in a Laravel Relationship and pulls out the relevant keys. I haven't included that in this PR in the interest of time.